### PR TITLE
Fix ProductCategory image

### DIFF
--- a/WooCommerce/Product.cs
+++ b/WooCommerce/Product.cs
@@ -953,7 +953,7 @@ namespace WooCommerceNET.WooCommerce
         /// Image data. See Category Image properties
         /// </summary>
         [DataMember(EmitDefaultValue = false)]
-        public List<ProductCategoryImage> image { get; set; }
+        public ProductCategoryImage image { get; set; }
 
         /// <summary>
         /// Menu order, used to custom sort the resource.


### PR DESCRIPTION
The ProductCategory image property does not have to be a List.