### PR TITLE
Decimal product weight | Extended classes serialize error 

### DIFF
--- a/Base/BaseObject.cs
+++ b/Base/BaseObject.cs
@@ -17,22 +17,19 @@ namespace WooCommerceNET.Base
             foreach (PropertyInfo pi in GetType().GetRuntimeProperties())
             {
                 PropertyInfo objValue = GetType().GetRuntimeProperties().FindByName(pi.Name + "Value");
-                if (objValue != null)
+                if (objValue != null && pi.GetValue(this) != null)
                 {
                     if (pi.PropertyType == typeof(decimal?))
                     {
-                        if (pi.GetValue(this) != null)
-                             objValue.SetValue(this, decimal.Parse(pi.GetValue(this).ToString()).ToString(CultureInfo.InvariantCulture));
+                        objValue.SetValue(this, (pi.GetValue(this) as decimal?).Value.ToString(CultureInfo.InvariantCulture));
                     }
                     else if (pi.PropertyType == typeof(int?))
                     {
-                        if (pi.GetValue(this) != null)
-                            objValue.SetValue(this, int.Parse(pi.GetValue(this).ToString(), CultureInfo.InvariantCulture));
+                        objValue.SetValue(this, int.Parse(pi.GetValue(this).ToString(), CultureInfo.InvariantCulture));
                     }
                     else if (pi.PropertyType == typeof(DateTime?))
                     {
-                        if (pi.GetValue(this) != null)
-                            objValue.SetValue(this, ((DateTime?)pi.GetValue(this)).Value.ToString("yyyy-MM-ddTHH:mm:ss"));
+                        objValue.SetValue(this, ((DateTime?)pi.GetValue(this)).Value.ToString("yyyy-MM-ddTHH:mm:ss"));
                     }
                 }
             }
@@ -71,7 +68,7 @@ namespace WooCommerceNET.Base
                 }
             }
         }
-        
+
 
         //[OnDeserializing]
         //void tset(StreamingContext ctx)
@@ -79,7 +76,7 @@ namespace WooCommerceNET.Base
         //    if (GetType().Name.Contains("ProductMeta"))
         //        foreach (PropertyInfo pi in GetType().GetRuntimeProperties())
         //        {
-                    
+
         //        }
         //}
     }
@@ -159,10 +156,10 @@ namespace WooCommerceNET.Base
         {
             return await API.PostRestful(APIEndpoint + "/batch", items, parms);
         }
-        
+
         public async Task<string> Delete(int id, bool force = false, Dictionary<string, string> parms = null)
         {
-            if(force)
+            if (force)
             {
                 if (parms == null)
                     parms = new Dictionary<string, string>();

--- a/WooCommerce/v1/Coupon.cs
+++ b/WooCommerce/v1/Coupon.cs
@@ -54,7 +54,7 @@ namespace WooCommerceNET.WooCommerce.v1
         /// The amount of discount.
         /// </summary>
         [DataMember(EmitDefaultValue = false, Name = "amount")]
-        private object amountValue { get; set; }
+        protected object amountValue { get; set; }
 
         public decimal? amount { get; set; }
 
@@ -132,14 +132,14 @@ namespace WooCommerceNET.WooCommerce.v1
         public bool? exclude_sale_items { get; set; }
 
         [DataMember(EmitDefaultValue = false, Name = "minimum_amount")]
-        private object minimum_amountValue { get; set; }
+        protected object minimum_amountValue { get; set; }
         /// <summary>
         /// Minimum order amount that needs to be in the cart before coupon applies.
         /// </summary>
         public decimal? minimum_amount { get; set; }
 
         [DataMember(EmitDefaultValue = false, Name = "maximum_amount")]
-        private object maximum_amountValue { get; set; }
+        protected object maximum_amountValue { get; set; }
         /// <summary>
         /// Maximum order amount allowed when using the coupon.
         /// </summary>

--- a/WooCommerce/v1/Order.cs
+++ b/WooCommerce/v1/Order.cs
@@ -202,7 +202,7 @@ namespace WooCommerceNET.WooCommerce.v1
         /// read-only
         /// </summary>
         [DataMember(EmitDefaultValue = false, Name = "date_paid")]
-        private object date_paidValue { get; set; }
+        protected object date_paidValue { get; set; }
 
         public DateTime? date_paid { get; set; }
 
@@ -375,14 +375,14 @@ namespace WooCommerceNET.WooCommerce.v1
         /// tax item total
         /// </summary>
         [DataMember(EmitDefaultValue = false, Name = "total")]
-        private object totalValue { get; set; }
+        protected object totalValue { get; set; }
         public decimal? total { get; set; }
 
         /// <summary>
         /// tax item subtotal
         /// </summary>
         [DataMember(EmitDefaultValue = false, Name = "subtotal")]
-        private object subtotalValue { get; set; }
+        protected object subtotalValue { get; set; }
         public decimal? subtotal { get; set; }
     }
 
@@ -413,7 +413,7 @@ namespace WooCommerceNET.WooCommerce.v1
         /// Line total (after discounts).
         /// </summary>
         [DataMember(EmitDefaultValue = false, Name = "total")]
-        private object totalValue { get; set; }
+        protected object totalValue { get; set; }
         public decimal? total { get; set; }
 
         /// <summary>
@@ -421,7 +421,7 @@ namespace WooCommerceNET.WooCommerce.v1
         /// read-only
         /// </summary>
         [DataMember(EmitDefaultValue = false, Name = "total_tax")]
-        private object total_taxValue { get; set; }
+        protected object total_taxValue { get; set; }
         public decimal? total_tax { get; set; }
 
         /// <summary>
@@ -474,7 +474,7 @@ namespace WooCommerceNET.WooCommerce.v1
         /// read-only
         /// </summary>
         [DataMember(EmitDefaultValue = false, Name = "tax_total")]
-        private object tax_totalValue { get; set; }
+        protected object tax_totalValue { get; set; }
         public decimal? tax_total { get; set; }
 
         /// <summary>
@@ -482,7 +482,7 @@ namespace WooCommerceNET.WooCommerce.v1
         /// read-only
         /// </summary>
         [DataMember(EmitDefaultValue = false, Name = "shipping_tax_total")]
-        private object shipping_tax_totalValue { get; set; }
+        protected object shipping_tax_totalValue { get; set; }
         public decimal? shipping_tax_total { get; set; }
     }
 
@@ -520,14 +520,14 @@ namespace WooCommerceNET.WooCommerce.v1
         /// Line total (after discounts).
         /// </summary>
         [DataMember(EmitDefaultValue = false, Name = "total")]
-        private object totalValue { get; set; }
+        protected object totalValue { get; set; }
         public decimal? total { get; set; }
 
         /// <summary>
         /// Line total tax (after discounts).
         /// </summary>
         [DataMember(EmitDefaultValue = false, Name = "total_tax")]
-        private object total_taxValue { get; set; }
+        protected object total_taxValue { get; set; }
         public decimal? total_tax { get; set; }
 
         /// <summary>
@@ -560,7 +560,7 @@ namespace WooCommerceNET.WooCommerce.v1
         /// required
         /// </summary>
         [DataMember(EmitDefaultValue = false, Name = "discount")]
-        private object discountValue { get; set; }
+        protected object discountValue { get; set; }
         public decimal? discount { get; set; }
 
         /// <summary>
@@ -568,7 +568,7 @@ namespace WooCommerceNET.WooCommerce.v1
         /// read-only
         /// </summary>
         [DataMember(EmitDefaultValue = false, Name = "discount_tax")]
-        private object discount_taxValue { get; set; }
+        protected object discount_taxValue { get; set; }
         public decimal? discount_tax { get; set; }
     }
 
@@ -625,7 +625,7 @@ namespace WooCommerceNET.WooCommerce.v1
         /// required
         /// </summary>
         [DataMember(EmitDefaultValue = false, Name = "amount")]
-        private object amountValue { get; set; }
+        protected object amountValue { get; set; }
         public decimal? amount { get; set; }
 
         /// <summary>

--- a/WooCommerce/v1/Product.cs
+++ b/WooCommerce/v1/Product.cs
@@ -98,7 +98,7 @@ namespace WooCommerceNET.WooCommerce.v1
         /// read-only
         /// </summary>
         [DataMember(EmitDefaultValue = false, Name = "price")]
-        private object priceValue { get; set; }
+        protected object priceValue { get; set; }
 
         public decimal? price { get; set; }
 
@@ -106,7 +106,7 @@ namespace WooCommerceNET.WooCommerce.v1
         /// Product regular price.
         /// </summary>
         [DataMember(EmitDefaultValue = false, Name = "regular_price")]
-        private object regular_priceValue { get; set; }
+        protected object regular_priceValue { get; set; }
 
         public decimal? regular_price { get; set; }
 
@@ -114,7 +114,7 @@ namespace WooCommerceNET.WooCommerce.v1
         /// Product sale price.
         /// </summary>
         [DataMember(EmitDefaultValue = false, Name = "sale_price")]
-        private object sale_priceValue { get; set; }
+        protected object sale_priceValue { get; set; }
 
         public decimal? sale_price { get; set; }
 
@@ -156,7 +156,7 @@ namespace WooCommerceNET.WooCommerce.v1
         /// read-only
         /// </summary>
         [DataMember(EmitDefaultValue = false, Name = "total_sales")]
-        private object total_salesValue { get; set; }
+        protected object total_salesValue { get; set; }
 
         public decimal? total_sales { get; set; }
 
@@ -269,7 +269,7 @@ namespace WooCommerceNET.WooCommerce.v1
         /// Product weight in decimal format.
         /// </summary>
         [DataMember(EmitDefaultValue = false, Name = "weight")]
-        private object weightValue { get; set; }
+        protected object weightValue { get; set; }
 
         public decimal? weight { get; set; }
 
@@ -659,21 +659,21 @@ namespace WooCommerceNET.WooCommerce.v1
         /// read-only
         /// </summary>
         [DataMember(EmitDefaultValue = false, Name = "price")]
-        private object priceValue { get; set; }
+        protected object priceValue { get; set; }
         public decimal? price { get; set; }
 
         /// <summary>
         /// Variation regular price.
         /// </summary>
         [DataMember(EmitDefaultValue = false, Name = "regular_price")]
-        private object regular_priceValue { get; set; }
+        protected object regular_priceValue { get; set; }
         public decimal? regular_price { get; set; }
 
         /// <summary>
         /// Variation sale price.
         /// </summary>
         [DataMember(EmitDefaultValue = false, Name = "sale_price")]
-        private object sale_priceValue { get; set; }
+        protected object sale_priceValue { get; set; }
         public decimal? sale_price { get; set; }
 
         /// <summary>
@@ -794,7 +794,7 @@ namespace WooCommerceNET.WooCommerce.v1
         /// Variation weight in decimal format.
         /// </summary>
         [DataMember(EmitDefaultValue = false, Name = "weight")]
-        private object weightValue { get; set; }
+        protected object weightValue { get; set; }
         public decimal? weight { get; set; }
 
         /// <summary>

--- a/WooCommerce/v2/Coupon.cs
+++ b/WooCommerce/v2/Coupon.cs
@@ -27,7 +27,7 @@ namespace WooCommerceNET.WooCommerce.v2
         public string code { get; set; }
 
         [DataMember(EmitDefaultValue = false, Name = "amount")]
-        private object amountValue { get; set; }
+        protected object amountValue { get; set; }
         /// <summary>
         /// The amount of discount. Should always be numeric, even if setting a percentage.
         /// </summary>

--- a/WooCommerce/v2/Customer.cs
+++ b/WooCommerce/v2/Customer.cs
@@ -112,13 +112,13 @@ namespace WooCommerceNET.WooCommerce.v2
         [DataMember(EmitDefaultValue = false)]
         public int? orders_count { get; set; }
 
-        private decimal? total_spent { get; set; }
+        [DataMember(EmitDefaultValue = false, Name = "total_spent")]
+        protected object total_spentValue { get; set; }
         /// <summary>
         /// Total amount spent. 
         /// read-only
         /// </summary>
-        [DataMember(EmitDefaultValue = false, Name = "total_spent")]
-        public object total_spentValue { get; set; }
+        public decimal? total_spent { get; set; }
 
         /// <summary>
         /// Avatar URL. 
@@ -204,7 +204,7 @@ namespace WooCommerceNET.WooCommerce.v2
         public string phone { get; set; }
 
     }
-    
+
     [DataContract]
     public class CustomerShipping
     {
@@ -263,13 +263,13 @@ namespace WooCommerceNET.WooCommerce.v2
         public string country { get; set; }
 
     }
-    
+
     [DataContract]
     public class CustomerMeta : WCObject.MetaData
     {
 
     }
-    
+
     [DataContract]
     public class CustomerDownloads
     {

--- a/WooCommerce/v2/Order.cs
+++ b/WooCommerce/v2/Order.cs
@@ -129,7 +129,7 @@ namespace WooCommerceNET.WooCommerce.v2
         public decimal? cart_tax { get; set; }
 
         [DataMember(EmitDefaultValue = false, Name = "total")]
-        private object totalValue { get; set; }
+        protected object totalValue { get; set; }
         /// <summary>
         /// Grand total. 
         /// read-only
@@ -137,7 +137,7 @@ namespace WooCommerceNET.WooCommerce.v2
         public decimal? total { get; set; }
 
         [DataMember(EmitDefaultValue = false, Name = "total_tax")]
-        private object total_taxValue { get; set; }
+        protected object total_taxValue { get; set; }
         /// <summary>
         /// Sum of all taxes. 
         /// read-only
@@ -483,14 +483,14 @@ namespace WooCommerceNET.WooCommerce.v2
         public decimal? subtotal_tax { get; set; }
 
         [DataMember(EmitDefaultValue = false, Name = "total")]
-        private object totalValue { get; set; }
+        protected object totalValue { get; set; }
         /// <summary>
         /// Line total (after discounts).
         /// </summary>
         public decimal? total { get; set; }
 
         [DataMember(EmitDefaultValue = false, Name = "total_tax")]
-        private object total_taxValue { get; set; }
+        protected object total_taxValue { get; set; }
         /// <summary>
         /// Line total tax (after discounts). 
         /// read-only
@@ -608,14 +608,14 @@ namespace WooCommerceNET.WooCommerce.v2
         public string method_id { get; set; }
 
         [DataMember(EmitDefaultValue = false, Name = "total")]
-        private object totalValue { get; set; }
+        protected object totalValue { get; set; }
         /// <summary>
         /// Line total (after discounts).
         /// </summary>
         public decimal? total { get; set; }
 
         [DataMember(EmitDefaultValue = false, Name = "total_tax")]
-        private object total_taxValue { get; set; }
+        protected object total_taxValue { get; set; }
         /// <summary>
         /// Line total tax (after discounts). 
         /// read-only
@@ -666,7 +666,7 @@ namespace WooCommerceNET.WooCommerce.v2
         public string tax_status { get; set; }
 
         [DataMember(EmitDefaultValue = false, Name = "total")]
-        private object totalValue { get; set; }
+        protected object totalValue { get; set; }
         /// <summary>
         /// Line total (after discounts).
         /// </summary>
@@ -748,7 +748,7 @@ namespace WooCommerceNET.WooCommerce.v2
         public string reason { get; set; }
 
         [DataMember(EmitDefaultValue = false, Name = "total")]
-        private object totalValue { get; set; }
+        protected object totalValue { get; set; }
         /// <summary>
         /// Refund total. 
         /// read-only

--- a/WooCommerce/v2/Product.cs
+++ b/WooCommerce/v2/Product.cs
@@ -109,7 +109,7 @@ namespace WooCommerceNET.WooCommerce.v2
         public string sku { get; set; }
         
         [DataMember(EmitDefaultValue = false, Name = "price")]
-        private object priceValue { get; set; }
+        protected object priceValue { get; set; }
         /// <summary>
         /// Current product price. 
         /// read-only
@@ -117,14 +117,14 @@ namespace WooCommerceNET.WooCommerce.v2
         public decimal? price { get; set; }
         
         [DataMember(EmitDefaultValue = false, Name = "regular_price")]
-        private object regular_priceValue { get; set; }
+        protected object regular_priceValue { get; set; }
         /// <summary>
         /// Product regular price.
         /// </summary>
         public decimal? regular_price { get; set; }
         
         [DataMember(EmitDefaultValue = false, Name = "sale_price")]
-        private object sale_priceValue { get; set; }
+        protected object sale_priceValue { get; set; }
         /// <summary>
         /// Product sale price.
         /// </summary>
@@ -281,7 +281,7 @@ namespace WooCommerceNET.WooCommerce.v2
         public bool? sold_individually { get; set; }
 
         [DataMember(EmitDefaultValue = false, Name = "weight")]
-        private object weightValue { get; set; }
+        protected object weightValue { get; set; }
         /// <summary>
         /// Product weight (kg).
         /// </summary>

--- a/WooCommerce/v2/Product.cs
+++ b/WooCommerce/v2/Product.cs
@@ -283,8 +283,10 @@ namespace WooCommerceNET.WooCommerce.v2
         /// <summary>
         /// Product weight (kg).
         /// </summary>
-        [DataMember(EmitDefaultValue = false)]
-        public string weight { get; set; }
+        [DataMember(EmitDefaultValue = false, Name = "weight")]
+        private object weightValue { get; set; }
+
+        public decimal? weight { get; set; }
 
         /// <summary>
         /// Product dimensions. See Product - Dimensions properties

--- a/WooCommerce/v2/Product.cs
+++ b/WooCommerce/v2/Product.cs
@@ -280,12 +280,11 @@ namespace WooCommerceNET.WooCommerce.v2
         [DataMember(EmitDefaultValue = false)]
         public bool? sold_individually { get; set; }
 
+        [DataMember(EmitDefaultValue = false, Name = "weight")]
+        private object weightValue { get; set; }
         /// <summary>
         /// Product weight (kg).
         /// </summary>
-        [DataMember(EmitDefaultValue = false, Name = "weight")]
-        private object weightValue { get; set; }
-
         public decimal? weight { get; set; }
 
         /// <summary>

--- a/WooCommerce/v2/Variation.cs
+++ b/WooCommerce/v2/Variation.cs
@@ -51,7 +51,7 @@ namespace WooCommerceNET.WooCommerce.v2
         public string sku { get; set; }
 
         [DataMember(EmitDefaultValue = false, Name = "price")]
-        private object priceValue { get; set; }
+        protected object priceValue { get; set; }
         /// <summary>
         /// Current variation price. 
         /// read-only
@@ -59,14 +59,14 @@ namespace WooCommerceNET.WooCommerce.v2
         public decimal? price { get; set; }
 
         [DataMember(EmitDefaultValue = false, Name = "regular_price")]
-        private object regular_priceValue { get; set; }
+        protected object regular_priceValue { get; set; }
         /// <summary>
         /// Variation regular price.
         /// </summary>
         public decimal? regular_price { get; set; }
 
         [DataMember(EmitDefaultValue = false, Name = "sale_price")]
-        private object sale_priceValue { get; set; }
+        protected object sale_priceValue { get; set; }
         /// <summary>
         /// Variation sale price.
         /// </summary>


### PR DESCRIPTION
- Use a decimal property in V2 for product weight as in V1 [will solve #160]
- Avoid unnecessary decimal.parse (decimal Type and value existence is already checked).
- Change private properties to protected to allow the correct use of inherited classes
GetType().GetRuntimeProperties().FindByName(pi.Name + "Value") [will solve #165]
- Fix: Customer total_spent property on v2