### PR TITLE
Added overload to Get Customer by Email

### DIFF
--- a/Base/BaseObject.cs
+++ b/Base/BaseObject.cs
@@ -137,7 +137,10 @@ namespace WooCommerceNET.Base
         {
             return API.DeserializeJSon<T>(await API.GetRestful(APIEndpoint + "/" + id.ToString(), parms).ConfigureAwait(false));
         }
-
+        public async Task<T> Get(string email, Dictionary<string, string> parms = null)
+        {
+            return API.DeserializeJSon<T>(await API.GetRestful(APIEndpoint + "/" + email, parms).ConfigureAwait(false));
+        }
         public async Task<List<T>> GetAll(Dictionary<string, string> parms = null)
         {
             return API.DeserializeJSon<List<T>>(await API.GetRestful(APIEndpoint, parms).ConfigureAwait(false));


### PR DESCRIPTION
The V1 and V2 interface allows to get customer by email. Added a new overload of WCItem Get to fetch customers by email.

Other objects can only be fetched by int. For clarity it might be considered to rename this method to GetCustomerByEmail.