### PR TITLE
Update Order.cs

### DIFF
--- a/WooCommerce/v2/Order.cs
+++ b/WooCommerce/v2/Order.cs
@@ -461,7 +461,7 @@ namespace WooCommerceNET.WooCommerce.v2
         /// Quantity ordered.
         /// </summary>
         [DataMember(EmitDefaultValue = false)]
-        public int? quantity { get; set; }
+        public decimal? quantity { get; set; }
 
         /// <summary>
         /// Tax class of product.


### PR DESCRIPTION
OrderLineItem quantity can be decimal. Order deserialization fails if quantity contains a fraction.