### PR TITLE
Add Errors object to product and variation

### DIFF
--- a/WooCommerce/v2/Product.cs
+++ b/WooCommerce/v2/Product.cs
@@ -13,6 +13,12 @@ namespace WooCommerceNET.WooCommerce.v2
         public static string Endpoint { get { return "products"; } }
 
         /// <summary>
+        /// Container for error information, if any
+        /// </summary>
+        [DataMember(EmitDefaultValue = false)]
+        public Error error { get; set; }
+
+        /// <summary>
         /// Unique identifier for the resource. 
         /// read-only
         /// </summary>
@@ -719,4 +725,13 @@ namespace WooCommerceNET.WooCommerce.v2
 
     }
 
+    [DataContract]
+    public class Error : JsonObject
+    {
+        [DataMember(EmitDefaultValue = false)]
+        public string code { get; set; }
+
+        [DataMember(EmitDefaultValue = false)]
+        public string message { get; set; }
+    }
 }

--- a/WooCommerce/v2/Variation.cs
+++ b/WooCommerce/v2/Variation.cs
@@ -10,6 +10,8 @@ namespace WooCommerceNET.WooCommerce.v2
     {
         public static string Endpoint { get { return "variations"; } }
 
+        [DataMember(EmitDefaultValue = false)]
+        public Error error { get; set; }
         /// <summary>
         /// Unique identifier for the resource. 
         /// read-only


### PR DESCRIPTION
Added an error object to product and variation as error info was being lost in deserialization.
Related to issue topic: [#313](https://github.com/XiaoFaye/WooCommerce.NET/issues/313#issue-370589291)