### PR TITLE
Specifiy user-agent when making requests to WooCommerce

### DIFF
--- a/RestAPI.cs
+++ b/RestAPI.cs
@@ -137,6 +137,7 @@ namespace WooCommerceNET
                 // start the stream immediately
                 httpWebRequest.Method = method.ToString();
                 httpWebRequest.AllowReadStreamBuffering = false;
+                httpWebRequest.UserAgent = "WooCommerce.NET";
 
                 if (webRequestFilter != null)
                     webRequestFilter.Invoke(httpWebRequest);


### PR DESCRIPTION
Some WooCommerce instances reject requests that don't have a UserAgent specified. Setting the UserAgent when making a request to WooCommerce, fixes this issue.