### PR TITLE
Use X-HTTP-MethodOverride header for DELETE/PUT

### DIFF
--- a/RestAPI.cs
+++ b/RestAPI.cs
@@ -162,6 +162,12 @@ namespace WooCommerceNET
                         Stream dataStream = await httpWebRequest.GetRequestStreamAsync().ConfigureAwait(false);
                         dataStream.Write(buffer, 0, buffer.Length);
                     }
+                }                
+                
+                if (method == RequestMethod.DELETE || method == RequestMethod.PUT)
+                {
+                    httpWebRequest.Headers.Add("X-HTTP-Method-Override", method.ToString());
+                    httpWebRequest.Method = "POST";
                 }
                 
                 // asynchronously get a response


### PR DESCRIPTION
Some Wordpress instances do not support DELETE/PUT verbs, so the
suggested fallback is to use the X-HTTP-MethodOverride header and send a
POST verb instead.

[WooCommerce docs](https://github.com/woocommerce/woocommerce/wiki/Getting-started-with-the-REST-API#server-does-not-support-postdeleteput)

[Wordpress docs](https://developer.wordpress.org/rest-api/using-the-rest-api/global-parameters/#_method-or-x-http-method-override-header)