### PR TITLE
Changed private access modifiers to protected in RestAPI

### DIFF
--- a/RestAPI.cs
+++ b/RestAPI.cs
@@ -16,17 +16,17 @@ namespace WooCommerceNET
 {
     public class RestAPI
     {
-        private string wc_url = string.Empty;
-        private string wc_key = "";
-        private string wc_secret = "";
+        protected string wc_url = string.Empty;
+        protected string wc_key = "";
+        protected string wc_secret = "";
         //private bool wc_Proxy = false;
 
-        private bool AuthorizedHeader { get; set; }
+        protected bool AuthorizedHeader { get; set; }
 
-        private Func<string, string> jsonSeFilter;
-        private Func<string, string> jsonDeseFilter;
-        private Action<HttpWebRequest> webRequestFilter;
-        private Action<HttpWebResponse> webResponseFilter;
+        protected Func<string, string> jsonSeFilter;
+        protected Func<string, string> jsonDeseFilter;
+        protected Action<HttpWebRequest> webRequestFilter;
+        protected Action<HttpWebResponse> webResponseFilter;
 
         /// <summary>
         /// For Wordpress REST API with OAuth 1.0 ONLY
@@ -302,7 +302,7 @@ namespace WooCommerceNET
             return await SendHttpClientRequest(endpoint, RequestMethod.DELETE, jsonObject, parms).ConfigureAwait(false);
         }
 
-        private string GetOAuthEndPoint(string method, string endpoint, Dictionary<string, string> parms = null)
+        protected string GetOAuthEndPoint(string method, string endpoint, Dictionary<string, string> parms = null)
         {
             if (Version == APIVersion.WordPressAPIJWT || (wc_url.StartsWith("https", StringComparison.OrdinalIgnoreCase) && Version != APIVersion.WordPressAPI))
             {
@@ -353,7 +353,7 @@ namespace WooCommerceNET
             return endpoint + "?" + parmstr.TrimEnd('&');
         }
 
-        private async Task<string> GetStreamContent(Stream s, string charset)
+        protected async Task<string> GetStreamContent(Stream s, string charset)
         {
             StringBuilder sb = new StringBuilder();
             byte[] Buffer = new byte[512];


### PR DESCRIPTION
Hi @XiaoFaye 

I had noticed that some of the implementations that `SendHttpClientRequest()` depends on are set as private meaning that any class that is derived from `RestAPI` and implements it's own `SendHttpClientRequest` will need to re-implement `GetOAuthEndPoint()` and `GetStreamContent()` etc

https://github.com/XiaoFaye/WooCommerce.NET/blob/69d90cee2e8b324baf7660099e73d57c7e23351b/RestAPI.cs#L147

https://github.com/XiaoFaye/WooCommerce.NET/blob/69d90cee2e8b324baf7660099e73d57c7e23351b/RestAPI.cs#L305

https://github.com/XiaoFaye/WooCommerce.NET/blob/69d90cee2e8b324baf7660099e73d57c7e23351b/RestAPI.cs#L356

I am proposing a change to the access modifiers to change them to protected from private so the derived class can access these implementations when overriding `SendHttpClientRequest()`

What do you think of this change?