### PR TITLE
Update Order.cs

### DIFF
--- a/WooCommerce/v2/Order.cs
+++ b/WooCommerce/v2/Order.cs
@@ -511,7 +511,7 @@ namespace WooCommerceNET.WooCommerce.v2
         /// Meta data. See Order - Meta data properties
         /// </summary>
         [DataMember(EmitDefaultValue = false)]
-        public List<OrderMeta> meta_data { get; set; }
+        public List<ProductMeta> meta_data { get; set; }
 
         /// <summary>
         /// Product SKU. 


### PR DESCRIPTION
Changed the line item meta to be of type ProductMeta instead of Order Meta. Not sure it matters, so much, I just had a conflict on converting a DTO, where I used ProductMeta.