### PR TITLE
Missing phone in OrderShipping

### DIFF
--- a/WooCommerce/v2/Order.cs
+++ b/WooCommerce/v2/Order.cs
@@ -421,6 +421,11 @@ namespace WooCommerceNET.WooCommerce.v2
         [DataMember(EmitDefaultValue = false)]
         public string country { get; set; }
 
+        /// <summary>
+        /// Phone number.
+        /// </summary>
+        [DataMember(EmitDefaultValue = false)]
+        public string phone { get; set; }
     }
 
     [DataContract]


### PR DESCRIPTION
In v3 I see that phone is flowing in OrderShipping, the field is missing.