### PR TITLE
Fixed update of products to use the http PUT method

### DIFF
--- a/Base/BaseObject.cs
+++ b/Base/BaseObject.cs
@@ -170,7 +170,7 @@ namespace WooCommerceNET.Base
 
         public virtual async Task<T> Update(ulong id, T item, Dictionary<string, string> parms = null)
         {
-            return API.DeserializeJSon<T>(await API.PostRestful(APIEndpoint + "/" + id.ToString(), item, parms).ConfigureAwait(false));
+            return API.DeserializeJSon<T>(await API.PutRestful(APIEndpoint + "/" + id.ToString(), item, parms).ConfigureAwait(false));
         }
 
         public virtual async Task<T> UpdateWithNull(ulong id, object item, Dictionary<string, string> parms = null)


### PR DESCRIPTION
WooCommerce now requires the PUT method to be used to update any items.