### PR TITLE
Correct OrderLineItem quantity to a ulong not a decimal

### DIFF
--- a/WooCommerce/v2/Order.cs
+++ b/WooCommerce/v2/Order.cs
@@ -461,7 +461,7 @@ namespace WooCommerceNET.WooCommerce.v2
         /// Quantity ordered.
         /// </summary>
         [DataMember(EmitDefaultValue = false)]
-        public decimal? quantity { get; set; }
+        public ulong? quantity { get; set; }
 
         /// <summary>
         /// Tax class of product.


### PR DESCRIPTION
Fixes #749

Went with ulong rather than a simple int to match other properties that are documented as integer but represented as ulong. Also kept nullability.