### PR TITLE
Accounting for situations where '-' symbol is returned for null numeric values

### DIFF
--- a/Base/BaseObject.cs
+++ b/Base/BaseObject.cs
@@ -59,21 +59,21 @@ namespace WooCommerceNET.Base
                     {
                         object value = objValue.GetValue(this);
 
-                        if (!(value == null || value.ToString() == string.Empty))
+                        if (!(value == null || value.ToString() == string.Empty || value.ToString() == "-"))
                             pi.SetValue(this, decimal.Parse(value.ToString(), Culture));
                     }
                     else if (pi.PropertyType == typeof(int?))
                     {
                         object value = objValue.GetValue(this);
 
-                        if (!(value == null || value.ToString() == string.Empty))
+                        if (!(value == null || value.ToString() == string.Empty || value.ToString() == "-"))
                             pi.SetValue(this, int.Parse(value.ToString(), Culture));
                     }
                     else if (pi.PropertyType == typeof(DateTime?))
                     {
                         object value = objValue.GetValue(this);
 
-                        if (!(value == null || value.ToString() == string.Empty))
+                        if (!(value == null || value.ToString() == string.Empty || value.ToString() == "-"))
                             pi.SetValue(this, DateTime.Parse(value.ToString()));
                     }
                 }


### PR DESCRIPTION
Example API response that is handled with the PR change:

...
"line_items": [
	{
		...
		"taxes": [
			{
				"id": 1,
				"total": "-",
				"subtotal": "-"
			}
		],
		...
	}
],
...