### PR TITLE
Update Product.cs - Variation Id type

### DIFF
--- a/WooCommerce/v3/Product.cs
+++ b/WooCommerce/v3/Product.cs
@@ -424,7 +424,7 @@ namespace WooCommerceNET.WooCommerce.v3
         /// read-only
         /// </summary>
         [DataMember(EmitDefaultValue = false)]
-        public List<int> variations { get; set; }
+        public List<ulong> variations { get; set; }
 
         /// <summary>
         /// List of grouped products ID. 


### PR DESCRIPTION
The variation ID type is incorrect, ids can be larger than an int.

Changed to uLong to match Variation.cs